### PR TITLE
Support output directry also for `psc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Invokes the `psc` command.
  - externs: String value that sets `--externs=<string>`
  - modules: String or array value that sets one or more `--module=<string>`
  - codegen: String or array value that sets one or more `--codegen=<string>`
+ - output: String value that sets `--output=<string>`
 
 ### purescript.pscMake(options)
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var gutil = require('gulp-util')
           main: '--main',
           verboseErrors: '--verbose-errors'
         }
-        , single: {browserNamespace: '--browser-namespace', externs: '--externs', main: '--main'}
+        , single: {browserNamespace: '--browser-namespace', externs: '--externs', main: '--main', output: '--output'}
         , multi: {modules: '--module', codegen: '--codegen'}
       },
       pscMake: {
@@ -80,7 +80,7 @@ function psc(opts) {
       if (!!code) that.emit('error', new gutil.PluginError(PLUGIN, buffer.toString()));
       else {
         that.push(new gutil.File({
-          path: 'psc.js',
+          path: (opts.output || 'psc.js'),
           contents: buffer
         }));
       }

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ var gutil = require('gulp-util')
   , assert = require('assert')
   , fs = require('fs')
   , purescript = require('./')
+  , os = require('os')
 ;
 
 it('should compile purescript', function(cb){
@@ -13,6 +14,32 @@ it('should compile purescript', function(cb){
 
   stream.on('data', function(file){
     assert(/Fixture/.test(file.contents.toString()));
+    cb();
+  });
+
+  fs.readFile(fixture, function(e, buffer){
+    if (e) cb(assert(false));
+    else {
+      stream.write(new gutil.File({
+        cwd: __dirname,
+        base: __dirname,
+        path: __dirname + '/' + fixture,
+        contents: buffer,
+        stat: {mtime: new Date()}
+      }));
+      stream.end();
+    }
+  });
+});
+
+it('should compile purescript to specified output', function(cb){
+  var fixture = 'Fixture.purs.hs'
+    , output  = os.tmpdir() + '/output.js'
+    , stream  = purescript.psc({noPrelude: true, output: output})
+  ;
+
+  stream.on('data', function(file){
+    assert.equal(output, file.path);
     cb();
   });
 


### PR DESCRIPTION
The name of compiled file was always `psc.js`. With this PR, this could be changed.
