### PR TITLE
Avoid empty error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ function psc(opts) {
       gutil.log('Stderr from \'' + gutil.colors.cyan('psc') + '\'\n' + gutil.colors.magenta(stderr));
     });
     cmd.on('close', function(code){
-      if (!!code) that.emit('error', new gutil.PluginError(PLUGIN, "psc has failed"));
+      if (!!code) fail(that, 'psc', buffer);
       else {
         that.push(new gutil.File({
           path: output,
@@ -116,7 +116,7 @@ function pscMake(opts) {
       gutil.log('Stderr from \'' + gutil.colors.cyan('psc-make') + '\'\n' + gutil.colors.magenta(stderr));
     });
     cmd.on('close', function(code){
-      if (!!code) that.emit('error', new gutil.PluginError(PLUGIN, 'psc-make has failed'));
+      if (!!code) fail(that, 'psc-make', buffer);
       cb();
     });
   });
@@ -136,7 +136,7 @@ function docgen(opts) {
       gutil.log('Stderr from \'' + gutil.colors.cyan('docgen') + '\'\n' + gutil.colors.magenta(stderr));
     });
     cmd.on('close', function(code){
-      if (!!code) that.emit('error', new gutil.PluginError(PLUGIN, "docgen failed"));
+      if (!!code) fail(that, 'docgen', buffer);
       else {
         that.push(new gutil.File({
           path: '.',
@@ -146,6 +146,11 @@ function docgen(opts) {
       cb();
     });
   });
+}
+
+function fail(plugin, tool, buffer) {
+  var msg = buffer.toString();
+  plugin.emit('error', new gutil.PluginError(PLUGIN, tool + ' has failed' + (msg ? ': ' + msg : '')));
 }
 
 module.exports = {


### PR DESCRIPTION
This fixes a problem where `psc` and `docgen` throw errors while throwing errors. That is, if a compilation error occurs during `psc` for example, we emit an error using `new gutil.PluginError(PLUGIN, buffer.toString())`, but `buffer.toString()` is null, so we get this error:

```
Error: Missing error message
    at new PluginError (/Users/tom/code/purescript-d3-examples/node_modules/gulp-purescript/node_modules/gulp-util/lib/PluginError.js:53:28)
    at ChildProcess.<anonymous> (/Users/tom/code/purescript-d3-examples/node_modules/gulp-purescript/index.js:94:38)
    at ChildProcess.emit (events.js:98:17)
    at maybeClose (child_process.js:755:16)
    at Socket.<anonymous> (child_process.js:968:11)
    at Socket.emit (events.js:95:17)
    at Pipe.close (net.js:465:12)
```

which can't be handled and causes gulp to exit. This is especially annoying when trying to use `gulp watch`.

The fix makes `psc` and `docgen` do the same thing as `pscMake`; that is, give a static failure message.
