### PR TITLE
Adding argument for verbose output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.log
 .psci
 node_modules
+output

--- a/README.md
+++ b/README.md
@@ -91,3 +91,8 @@ Invokes the `pscDocs` command.
 
 Generates a `.psci` file in the current directory. Each source file is
 added with the `:m` command.
+
+## Command line arguments
+
+The `--verbose` argument will display the output during the `psc-make`
+command. For example `gulp --verbose`.

--- a/options.js
+++ b/options.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var options = {
+  psc: {
+    cmd: 'psc',
+    flags: {
+      noPrelude: '--no-prelude',
+      noOpts: '--no-opts',
+      noMagicDo: '--no-magic-do',
+      noTco: '--no-tco',
+      main: '--main',
+      verboseErrors: '--verbose-errors'
+    }
+    , single: {browserNamespace: '--browser-namespace', externs: '--externs', main: '--main', output: '--output'}
+    , multi: {modules: '--module', codegen: '--codegen'}
+  },
+  pscMake: {
+    cmd: 'psc-make',
+    flags: {
+      noPrelude: '--no-prelude',
+      noOpts: '--no-opts',
+      noMagicDo: '--no-magic-do',
+      noTco: '--no-tco',
+      verboseErrors: '--verbose-errors'
+    }
+    , single: {browserNamespace: '--browser-namespace', output: '--output'}
+    , multi: {}
+  },
+  pscDocs: {
+    cmd: 'psc-docs',
+    flags: {
+      hierarchy: '--hierarchy-images'
+    }
+    , single: {}
+    , multi: {}
+  }
+};
+
+module.exports = options;

--- a/package.json
+++ b/package.json
@@ -8,27 +8,33 @@
     "name": "Eric",
     "email": "thul.eric@gmail.com"
   },
-  "engineStrict": true,
   "engines": {
-    "node": ">=0.10"
+    "node": ">=0.10.0"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "options.js"
   ],
   "scripts": {
-    "test": "mocha"
+    "test": "node test.js | tap-spec"
   },
   "keywords": [
     "gulpplugin",
     "purescript"
   ],
   "dependencies": {
-    "gulp-util": "^2.2.14",
-    "lodash": "^2.4.1",
-    "through2": "^0.4.1",
-    "which": "^1.0.5"
+    "gulp-util": "^3.0.4",
+    "lodash": "^3.5.0",
+    "logalot": "^2.1.0",
+    "minimist": "^1.1.1",
+    "multipipe": "^0.1.2",
+    "through2": "^0.6.3",
+    "which": "^1.0.9"
   },
   "devDependencies": {
-    "mocha": "*"
+    "gulp": "^3.8.11",
+    "rewire": "^2.3.1",
+    "tap-spec": "^2.2.2",
+    "tape": "^3.5.0"
   }
 }


### PR DESCRIPTION
The new `--verbose` argument may be passed to `gulp` in order to log the
output from `psc-make`. By default the `pscMake` task only log output if
an error occurs.

This resolves #17 and resolves #7