### PR TITLE
Updates 0.7

### DIFF
--- a/MODULE.md
+++ b/MODULE.md
@@ -140,47 +140,6 @@ multipipe2 :: forall a b c. Stream a b -> Stream b c -> Stream a c
 
 
 
-## Module GulpPurescript.OS
-
-#### `OS`
-
-``` purescript
-data OS :: !
-```
-
-
-#### `Platform`
-
-``` purescript
-data Platform
-  = Darwin 
-  | Linux 
-  | Win32 
-```
-
-
-#### `showPlatform`
-
-``` purescript
-instance showPlatform :: Show Platform
-```
-
-
-#### `isForeignPlatform`
-
-``` purescript
-instance isForeignPlatform :: IsForeign Platform
-```
-
-
-#### `platform`
-
-``` purescript
-platform :: forall eff. Eff (os :: OS | eff) (Maybe Platform)
-```
-
-
-
 ## Module GulpPurescript.Options
 
 #### `isForeignEither`
@@ -243,6 +202,47 @@ pscMakeOptions :: Foreign -> [String]
 
 ``` purescript
 pscDocsOptions :: Foreign -> [String]
+```
+
+
+
+## Module GulpPurescript.OS
+
+#### `OS`
+
+``` purescript
+data OS :: !
+```
+
+
+#### `Platform`
+
+``` purescript
+data Platform
+  = Darwin 
+  | Linux 
+  | Win32 
+```
+
+
+#### `showPlatform`
+
+``` purescript
+instance showPlatform :: Show Platform
+```
+
+
+#### `isForeignPlatform`
+
+``` purescript
+instance isForeignPlatform :: IsForeign Platform
+```
+
+
+#### `platform`
+
+``` purescript
+platform :: forall eff. Eff (os :: OS | eff) (Maybe Platform)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Toggles `--no-prefix` that does not include the comment header.
 
 ###### `ffi` (String Array)
 
-Sets one or more `--ffi=<string>` that specifies the location of files for code that is included with a `foreign import` in the PureScript source.
+Sets one or more `--ffi=<string>` that specifies the files for code that is included with a `foreign import` in the PureScript source.
 
 ### `purescript.pscMake(options)`
 
@@ -130,7 +130,7 @@ Toggles `--no-prefix` that does not include the comment header.
 
 ###### `ffi` (String Array)
 
-Sets one or more `--ffi=<string>` that specifies the location of files for code that is included with a `foreign import` in the PureScript source.
+Sets one or more `--ffi=<string>` that specifies files for code that is included with a `foreign import` in the PureScript source.
 
 ### `purescript.pscDocs(options)`
 
@@ -139,6 +139,14 @@ Invokes the `pscDocs` command. The following options are supported.
 ###### `format` (markdown | etags | ctags)
 
 Sets `--output=<markdown|etags|ctags>` that specifies the output format.
+
+###### `docgen` (String | String Array | Object)
+
+Sets `--docgen=...` that can be used to filter the modules documentation is generated for.
+
+- If a string value is provided, the documentation for that single module will be generated.
+- If a list of strings is provided, the documentation for all listed modules will be generated.
+- If an object with module name/filename pairs (for example, `{ Module: "docs/Module.md" }`) is provided, files will be written for each of the modules. In this mode, the task requires no `dest` as no value is returned.
 
 ### `purescript.dotPsci()`
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "purescript"
   ],
   "dependencies": {
+    "glob": "^5.0.5",
     "gulp-util": "^3.0.4",
     "logalot": "^2.1.0",
     "minimist": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-purescript",
   "description": "Run the PureScript compiler",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "license": "MIT",
   "repository": "purescript-contrib/gulp-purescript",
   "author": {

--- a/src/Options.purs
+++ b/src/Options.purs
@@ -116,60 +116,58 @@ instance isForeignEither :: (IsForeign a, IsForeign b) => IsForeign (Either a b)
 
 instance isForeignPsc :: IsForeign Psc where
   read obj =
-    (\a b c d e f g h i j k l m o ->
-    Psc { noPrelude: a
-        , noTco: b
-        , noMagicDo: c
-        , main: d
-        , noOpts: e
-        , verboseErrors: f
-        , comments: g
-        , browserNamespace: h
-        , "module": i
-        , codegen: j
-        , output: k
-        , externs: l
-        , noPrefix: m
-        , ffi: o
-        }) <$> readProp noPreludeKey obj
-           <*> readProp noTcoKey obj
-           <*> readProp noMagicDoKey obj
-           <*> readProp mainKey obj
-           <*> readProp noOptsKey obj
-           <*> readProp verboseErrorsKey obj
-           <*> readProp commentsKey obj
-           <*> readProp browserNamespaceKey obj
-           <*> readProp moduleKey obj
-           <*> readProp codegenKey obj
-           <*> readProp outputKey obj
-           <*> readProp externsKey obj
-           <*> readProp noPrefixKey obj
-           <*> readProp ffiKey obj
-
-instance isForeignPscMake :: IsForeign PscMake where
-  read obj =
-    (\a b c d e f g h i ->
-    PscMake { output: a
-            , noPrelude: b
-            , noTco: c
-            , noMagicDo: d
-            , noOpts: e
-            , verboseErrors: f
-            , comments: g
-            , noPrefix: h
-            , ffi: i
-            }) <$> readProp outputKey obj
-               <*> readProp noPreludeKey obj
+    Psc <$> ({ noPrelude: _
+             , noTco: _
+             , noMagicDo: _
+             , main: _
+             , noOpts: _
+             , verboseErrors: _
+             , comments: _
+             , browserNamespace: _
+             , "module": _
+             , codegen: _
+             , output: _
+             , externs: _
+             , noPrefix: _
+             , ffi: _
+             } <$> readProp noPreludeKey obj
                <*> readProp noTcoKey obj
                <*> readProp noMagicDoKey obj
+               <*> readProp mainKey obj
                <*> readProp noOptsKey obj
                <*> readProp verboseErrorsKey obj
                <*> readProp commentsKey obj
+               <*> readProp browserNamespaceKey obj
+               <*> readProp moduleKey obj
+               <*> readProp codegenKey obj
+               <*> readProp outputKey obj
+               <*> readProp externsKey obj
                <*> readProp noPrefixKey obj
-               <*> readProp ffiKey obj
+               <*> readProp ffiKey obj)
+
+instance isForeignPscMake :: IsForeign PscMake where
+  read obj =
+    PscMake <$> ({ output: _
+                 , noPrelude: _
+                 , noTco: _
+                 , noMagicDo: _
+                 , noOpts: _
+                 , verboseErrors: _
+                 , comments: _
+                 , noPrefix: _
+                 , ffi: _
+                 } <$> readProp outputKey obj
+                   <*> readProp noPreludeKey obj
+                   <*> readProp noTcoKey obj
+                   <*> readProp noMagicDoKey obj
+                   <*> readProp noOptsKey obj
+                   <*> readProp verboseErrorsKey obj
+                   <*> readProp commentsKey obj
+                   <*> readProp noPrefixKey obj
+                   <*> readProp ffiKey obj)
 
 instance isForeignPscDocs :: IsForeign PscDocs where
-  read obj = (\a -> PscDocs { format: a }) <$> readProp formatKey obj
+  read obj = PscDocs <<< { format: _ } <$> readProp formatKey obj
 
 instance isForeignFormat :: IsForeign Format where
   read val = read val >>= (\a -> case a of


### PR DESCRIPTION
More changes :)

- The `ffi` option I added wasn't very useful in its previous form, as you'd always have to specify the full list of file paths or use `glob` to do the work - figured I may as well integrate that into the plugin.
- Added `docgen` option for `psc-docs` - it works a bit like `codegen` for `psc`: `psc-docs` now requires all the input files, so this option lets you filter what modules to generate the docs for. It has a few permutations that are acceptable in the config:

``` javascript

// Write individual files for the specified modules. The process writes nothing to stdout in this case.
purescript.pscDocs({
  docgen: {
    "Prelude": "docs/Prelude.md"
    "Prelude.Unsafe": "docs/Prelude.Unsafe.md"
  }
})

// Only generate docs for one module
purescript.pscDocs({
  docgen: "Prelude"
})

// Only generate docs for the listed modules, all included in the output
purescript.pscDocs({
  docgen: ["Prelude", "Prelude.Unsafe"]
})
```