### PR TITLE
Using cross-spawn as a drop-in for child_process

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "purescript"
   ],
   "dependencies": {
+    "cross-spawn": "^0.4.0",
+    "glob": "^5.0.5",
     "gulp-util": "^3.0.4",
     "logalot": "^2.1.0",
     "minimist": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   ],
   "dependencies": {
     "cross-spawn": "^0.4.0",
-    "glob": "^5.0.5",
     "gulp-util": "^3.0.4",
     "logalot": "^2.1.0",
     "minimist": "^1.1.1",

--- a/src/ChildProcess.purs
+++ b/src/ChildProcess.purs
@@ -17,7 +17,7 @@ spawn command args = makeAff $ runFn4 spawnFn command args
 foreign import spawnFn """
 function spawnFn(command, args, errback, callback) {
   return function(){
-    var child_process = require('child_process');
+    var child_process = require('cross-spawn');
 
     var process = child_process.spawn(command, args);
 


### PR DESCRIPTION
Until joyent/node#2318 is resolved, opting for `cross-spawn` instead of
using `child_process` directly to provide better windows compatibility.

Resolves #30

(cherry picked from commit 16f0539aa9f7279325ac80a07bf4b3fcd2d5a1a4)